### PR TITLE
remove redundant jobs

### DIFF
--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -7,45 +7,19 @@ on:
     if: github.actor in ['jupierce', 'sosiouxme', 'thiagoalessio', 'joepvd', 'thegreyd', 'vfreex', 'locriandev', 'Ximinhan', 'ashwindasr']
 
 jobs:
-  pr-job:
+  snyk:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
     steps:
-      - uses: actions/checkout@v3
-      - name: Run PR job specific steps
-        run: echo "This is a PR job-specific step"
+      - uses: actions/checkout@master
       - name: Test for open source vulnerabilities and license issues.
         uses: snyk/actions/python-3.9@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: test
-          args: --all-projects
       - name: Test for any known security issues using Static Code Analysis.
         uses: snyk/actions/python-3.9@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: code test
-          args: --all-projects
-  push-job:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run Push job specific steps
-        run: echo "This is a push job-specific step"
-      - name: Test for open source vulnerabilities and license issues.
-        uses: snyk/actions/python-3.9@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          command: test
-          args: --all-projects
-      - name: Test for any known security issues using Static Code Analysis.
-        uses: snyk/actions/python-3.9@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          command: code test
-          args: --all-projects


### PR DESCRIPTION
No need to run two jobs since the only update that we needed to give access to the PR github actions event run was pull_request_target